### PR TITLE
Replace deprecated ParserOutput setters in disable_discovery

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -46,8 +46,8 @@ class Hooks implements
 	 * @param string $text
 	 */
 	public function parserFunctionDisableDiscovery( Parser $parser, string $text ) {
-		$parser->getOutput()->setPageProperty( 'discovery-disabled', true );
-		$parser->getOutput()->addJsConfigVars( 'discovery-disabled', true );
+		$parser->getOutput()->setUnsortedPageProperty( 'discovery-disabled', '1' );
+		$parser->getOutput()->setJsConfigVar( 'discovery-disabled', true );
 	}
 
 	/**


### PR DESCRIPTION
## What

`parserFunctionDisableDiscovery` used two deprecated `ParserOutput` APIs, emitting these on every parse of a page that uses `{{#disable_discovery:}}`:

- `setPageProperty('discovery-disabled', true)` — non-string value, deprecated in MW 1.42
- `addJsConfigVars('discovery-disabled', true)` — deprecated in MW 1.38

## Change

- `setPageProperty(…, true)` → `setUnsortedPageProperty('discovery-disabled', '1')`
- `addJsConfigVars(…)` → `setJsConfigVar('discovery-disabled', true)`

## Why it's safe

All four consumers read the flag only for truthiness, so `'1'` (PHP page property) and `true` (JS config var) are drop-in equivalent:
- `src/Hooks.php` `renderTagDiscovery` / `onOutputPageParserOutput`
- `modules/discovery.script.js` (`mw.config.get('discovery-disabled')`)
- `SkinCassandra.php` (`!$out->getProperty('discovery-disabled')`)

`setJsConfigVar` only throws on a *conflicting* value for the same key; this sets a single constant `true`, so it's fine.

## Related

Paired with the staging error-display fix in PR https://github.com/kolzchut/kz-mediawiki-main/pull/58: that stops *other* deprecations reaching the screen on staging; this removes these two at the source. The main-site Discovery submodule pointer should be bumped to this PR's merge commit once merged.